### PR TITLE
Glimpse: Request ACCESS_MEDIA_LOCATION in Q+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 
     <application
         android:name="org.lineageos.glimpse.GlimpseApplication"

--- a/app/src/main/java/org/lineageos/glimpse/utils/PermissionsUtils.kt
+++ b/app/src/main/java/org/lineageos/glimpse/utils/PermissionsUtils.kt
@@ -35,6 +35,9 @@ class PermissionsUtils(private val context: Context) {
             } else {
                 add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
             }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                add(Manifest.permission.ACCESS_MEDIA_LOCATION)
+            }
         }.toTypedArray()
     }
 }


### PR DESCRIPTION
It's required to read the media location.