### PR TITLE
Glimpse: Update workflows versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,13 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
-    - name: Setup JDK 11
-      uses: actions/setup-java@v1
+    - name: Setup JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        distribution: 'zulu'
+        java-version: 17
 
     - name: Build with Gradle
       run: ./gradlew assembleDebug


### PR DESCRIPTION
They use node12 that is deprecated.

Change-Id: I88864db207ffbc353ee4fc05477c98e962c3e158