### PR TITLE
Glimpse: Preserve last seen media position

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/fragments/MediaViewerFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/MediaViewerFragment.kt
@@ -80,12 +80,14 @@ class MediaViewerFragment : Fragment(
     private val loaderManagerInstance by lazy { LoaderManager.getInstance(this) }
 
     // Arguments
-    private val position by lazy { arguments?.getInt(KEY_POSITION, -1)!! }
+    private var position = -1
     private val album by lazy { arguments?.getParcelable(KEY_ALBUM, Album::class) }
 
     private val onPageChangeCallback = object : OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
             super.onPageSelected(position)
+
+            this@MediaViewerFragment.position = position
 
             val media = mediaViewerAdapter.getMediaFromMediaStore(position) ?: return
 
@@ -96,6 +98,8 @@ class MediaViewerFragment : Fragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        position = arguments?.getInt(KEY_POSITION, -1)!!
 
         backButton.setOnClickListener {
             findNavController().popBackStack()


### PR DESCRIPTION
Otherwise resuming the fragment will go back to
the original media.

Change-Id: I9433f353782afb0ae006de4d2906842299f34e82