### PR TITLE
Glimpse: Set android:configChanges for MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:theme="@style/Theme.Glimpse">
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|screenLayout|screenSize|smallestScreenSize|keyboardHidden"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/org/lineageos/glimpse/fragments/AlbumFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/AlbumFragment.kt
@@ -5,6 +5,7 @@
 
 package org.lineageos.glimpse.fragments
 
+import android.content.res.Configuration
 import android.database.Cursor
 import android.os.Bundle
 import android.provider.MediaStore
@@ -116,6 +117,14 @@ class AlbumFragment : Fragment(R.layout.fragment_album), LoaderManager.LoaderCal
         } else {
             initCursorLoader()
         }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+
+        albumRecyclerView.layoutManager = ThumbnailLayoutManager(
+            requireContext(), thumbnailAdapter
+        )
     }
 
     override fun onCreateLoader(id: Int, args: Bundle?) = when (id) {

--- a/app/src/main/java/org/lineageos/glimpse/fragments/ReelsFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/ReelsFragment.kt
@@ -5,6 +5,7 @@
 
 package org.lineageos.glimpse.fragments
 
+import android.content.res.Configuration
 import android.database.Cursor
 import android.os.Bundle
 import android.provider.MediaStore
@@ -99,6 +100,14 @@ class ReelsFragment : Fragment(R.layout.fragment_reels), LoaderManager.LoaderCal
         } else {
             initCursorLoader()
         }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+
+        reelsRecyclerView.layoutManager = ThumbnailLayoutManager(
+            requireContext(), thumbnailAdapter
+        )
     }
 
     override fun onCreateLoader(id: Int, args: Bundle?) = when (id) {


### PR DESCRIPTION
We don't want to restart activity on config changes.

Test: Play video and rotate the device, notice that it no longer rewinds
        the playback to 0s.