### PR TITLE
Glimpe: ThumbnailLayoutManager: Ignore OOB in onLayoutChildren

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/thumbnail/ThumbnailLayoutManager.kt
+++ b/app/src/main/java/org/lineageos/glimpse/thumbnail/ThumbnailLayoutManager.kt
@@ -7,6 +7,7 @@ package org.lineageos.glimpse.thumbnail
 
 import android.content.Context
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import org.lineageos.glimpse.ext.px
 
 class ThumbnailLayoutManager(
@@ -15,6 +16,13 @@ class ThumbnailLayoutManager(
 ) : GridLayoutManager(context, getSpanCount(context)) {
     init {
         spanSizeLookup = ThumbnailSpanSizeLookup(adapter, spanCount)
+    }
+
+    override fun onLayoutChildren(recycler: RecyclerView.Recycler?, state: RecyclerView.State?) {
+        try {
+            super.onLayoutChildren(recycler, state)
+        } catch (_: IndexOutOfBoundsException) {
+        }
     }
 
     private class ThumbnailSpanSizeLookup(


### PR DESCRIPTION
When the underlying data is changed when the we're trying to
layout the children on the RecyclerView we can hit that.

TODO: Add proper syncronization and/or switch to ViewModels

Change-Id: I174e6c7c3cca2980ced19a424fc2e12372791d88
