### PR TITLE
Glimpse: Specify size of the image to load

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/fragments/MediaViewerFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/MediaViewerFragment.kt
@@ -294,6 +294,7 @@ class MediaViewerFragment : Fragment(
         }
 
         viewPager.adapter = mediaViewerAdapter
+        viewPager.offscreenPageLimit = 2
         viewPager.registerOnPageChangeCallback(onPageChangeCallback)
 
         shareButton.setOnClickListener {

--- a/app/src/main/java/org/lineageos/glimpse/thumbnail/AlbumThumbnailAdapter.kt
+++ b/app/src/main/java/org/lineageos/glimpse/thumbnail/AlbumThumbnailAdapter.kt
@@ -15,6 +15,7 @@ import androidx.navigation.NavController
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import org.lineageos.glimpse.R
+import org.lineageos.glimpse.ext.*
 import org.lineageos.glimpse.fragments.AlbumFragment
 import org.lineageos.glimpse.models.Album
 
@@ -75,6 +76,7 @@ class AlbumThumbnailAdapter(
             )
 
             thumbnailImageView.load(album.thumbnail) {
+                size(ThumbnailLayoutManager.MAX_THUMBNAIL_SIZE.px)
                 placeholder(R.drawable.thumbnail_placeholder)
             }
 

--- a/app/src/main/java/org/lineageos/glimpse/thumbnail/ThumbnailAdapter.kt
+++ b/app/src/main/java/org/lineageos/glimpse/thumbnail/ThumbnailAdapter.kt
@@ -17,6 +17,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import org.lineageos.glimpse.R
+import org.lineageos.glimpse.ext.*
 import org.lineageos.glimpse.models.Media
 import org.lineageos.glimpse.models.MediaType
 import java.time.ZoneId
@@ -192,6 +193,7 @@ class ThumbnailAdapter(
             this.position = position
 
             thumbnailImageView.load(media.externalContentUri) {
+                size(ThumbnailLayoutManager.MAX_THUMBNAIL_SIZE.px)
                 placeholder(R.drawable.thumbnail_placeholder)
             }
             videoOverlayImageView.isVisible = media.mediaType == MediaType.VIDEO

--- a/app/src/main/java/org/lineageos/glimpse/thumbnail/ThumbnailLayoutManager.kt
+++ b/app/src/main/java/org/lineageos/glimpse/thumbnail/ThumbnailLayoutManager.kt
@@ -43,7 +43,7 @@ class ThumbnailLayoutManager(
         /**
          * Maximum thumbnail size, useful for high density screens.
          */
-        private const val MAX_THUMBNAIL_SIZE = 128
+        const val MAX_THUMBNAIL_SIZE = 128
 
         private enum class Orientation {
             VERTICAL,


### PR DESCRIPTION
It allows Coil to avoid caching the whole image for reel viewing

Change-Id: I0994848364aea8592325570b8dcfd6fe9efd713b
