### PR TITLE
Glimpse: Improve Album::equals() implementation

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/models/Album.kt
+++ b/app/src/main/java/org/lineageos/glimpse/models/Album.kt
@@ -29,7 +29,14 @@ data class Album(
 
     override fun equals(other: Any?): Boolean {
         val obj = Album::class.safeCast(other) ?: return false
-        return id == obj.id
+        return compareValuesBy(
+            this,
+            obj,
+            { it.id },
+            { it.name },
+            { it.thumbnail },
+            { it.size },
+        ) == 0
     }
 
     override fun hashCode() = id.hashCode()


### PR DESCRIPTION
Let's just compare all fields instead of just the id.

Test: Go to albums, take a screenshot and notice that "{} items"
      increased by one.
Change-Id: I770bb31ccd02964672280c0dffe393d1d2f005fd