### PR TITLE
Glimpse: Coroutines improvements

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/ext/ContentResolver.kt
+++ b/app/src/main/java/org/lineageos/glimpse/ext/ContentResolver.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.isActive
 
 @RequiresApi(Build.VERSION_CODES.R)
 fun ContentResolver.createDeleteRequest(vararg uris: Uri) = IntentSenderRequest.Builder(
@@ -41,7 +42,9 @@ fun ContentResolver.createTrashRequest(value: Boolean, vararg uris: Uri) =
 fun ContentResolver.uriFlow(uri: Uri) = callbackFlow {
     val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
         override fun onChange(selfChange: Boolean) {
-            trySend(Unit)
+            if (isActive) {
+                trySend(Unit)
+            }
         }
     }
     registerContentObserver(uri, true, observer)

--- a/app/src/main/java/org/lineageos/glimpse/repository/MediaRepository.kt
+++ b/app/src/main/java/org/lineageos/glimpse/repository/MediaRepository.kt
@@ -6,13 +6,15 @@
 package org.lineageos.glimpse.repository
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOn
 import org.lineageos.glimpse.flow.AlbumsFlow
 import org.lineageos.glimpse.flow.MediaFlow
 
 @Suppress("Unused")
 class MediaRepository(private val context: Context) {
-    fun media(bucketId: Int? = null) = MediaFlow(context, bucketId).flowData()
-    fun mediaCursor(bucketId: Int? = null) = MediaFlow(context, bucketId).flowCursor()
-    fun albums() = AlbumsFlow(context).flowData()
-    fun albumsCursor() = AlbumsFlow(context).flowCursor()
+    fun media(bucketId: Int? = null) = MediaFlow(context, bucketId).flowData().flowOn(Dispatchers.IO)
+    fun mediaCursor(bucketId: Int? = null) = MediaFlow(context, bucketId).flowCursor().flowOn(Dispatchers.IO)
+    fun albums() = AlbumsFlow(context).flowData().flowOn(Dispatchers.IO)
+    fun albumsCursor() = AlbumsFlow(context).flowCursor().flowOn(Dispatchers.IO)
 }


### PR DESCRIPTION
- Glimpse: Only send ContentObserver callbacks when Job is active
- Glimpse: Flow content provides flows on IO dispatcher
