### PR TITLE
stateflow

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/fragments/AlbumFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/AlbumFragment.kt
@@ -44,7 +44,9 @@ import org.lineageos.glimpse.viewmodels.MediaViewModel
  */
 class AlbumFragment : Fragment(R.layout.fragment_album) {
     // View models
-    private val mediaViewModel: MediaViewModel by viewModels { MediaViewModel.Factory }
+    private val mediaViewModel: MediaViewModel by viewModels {
+        MediaViewModel.factory(lifecycleScope, album.id)
+    }
 
     // Views
     private val albumRecyclerView by getViewProperty<RecyclerView>(R.id.albumRecyclerView)
@@ -54,10 +56,9 @@ class AlbumFragment : Fragment(R.layout.fragment_album) {
     // Permissions
     private val permissionsGatedCallback = PermissionsGatedCallback(this) {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                mediaViewModel.setBucketId(album.id)
-                mediaViewModel.mediaForAlbum.collectLatest { data ->
-                    thumbnailAdapter.data = data.toTypedArray()
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                mediaViewModel.media.collectLatest {
+                    thumbnailAdapter.data = it.toTypedArray()
                 }
             }
         }

--- a/app/src/main/java/org/lineageos/glimpse/fragments/AlbumsFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/AlbumsFragment.kt
@@ -31,7 +31,7 @@ import org.lineageos.glimpse.ext.*
 import org.lineageos.glimpse.recyclerview.AlbumThumbnailAdapter
 import org.lineageos.glimpse.recyclerview.AlbumThumbnailLayoutManager
 import org.lineageos.glimpse.utils.PermissionsGatedCallback
-import org.lineageos.glimpse.viewmodels.MediaViewModel
+import org.lineageos.glimpse.viewmodels.AlbumsViewModel
 
 /**
  * An albums list visualizer.
@@ -40,7 +40,7 @@ import org.lineageos.glimpse.viewmodels.MediaViewModel
  */
 class AlbumsFragment : Fragment() {
     // View models
-    private val mediaViewModel: MediaViewModel by viewModels { MediaViewModel.Factory }
+    private val albumsViewModel: AlbumsViewModel by viewModels { AlbumsViewModel.Factory }
 
     // Views
     private val albumsRecyclerView by getViewProperty<RecyclerView>(R.id.albumsRecyclerView)
@@ -55,7 +55,7 @@ class AlbumsFragment : Fragment() {
     private val permissionsGatedCallback = PermissionsGatedCallback(this) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                mediaViewModel.albums.collectLatest {
+                albumsViewModel.albums.collectLatest {
                     albumThumbnailAdapter.data = it.toTypedArray()
                 }
             }

--- a/app/src/main/java/org/lineageos/glimpse/fragments/AlbumsFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/AlbumsFragment.kt
@@ -40,7 +40,9 @@ import org.lineageos.glimpse.viewmodels.AlbumsViewModel
  */
 class AlbumsFragment : Fragment() {
     // View models
-    private val albumsViewModel: AlbumsViewModel by viewModels { AlbumsViewModel.Factory }
+    private val albumsViewModel: AlbumsViewModel by viewModels {
+        AlbumsViewModel.factory(lifecycleScope)
+    }
 
     // Views
     private val albumsRecyclerView by getViewProperty<RecyclerView>(R.id.albumsRecyclerView)
@@ -54,7 +56,7 @@ class AlbumsFragment : Fragment() {
     // Permissions
     private val permissionsGatedCallback = PermissionsGatedCallback(this) {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 albumsViewModel.albums.collectLatest {
                     albumThumbnailAdapter.data = it.toTypedArray()
                 }

--- a/app/src/main/java/org/lineageos/glimpse/fragments/MediaViewerFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/MediaViewerFragment.kt
@@ -56,7 +56,11 @@ import java.text.SimpleDateFormat
  */
 class MediaViewerFragment : Fragment(R.layout.fragment_media_viewer) {
     // View models
-    private val mediaViewModel: MediaViewerViewModel by viewModels { MediaViewerViewModel.Factory }
+    private val mediaViewModel: MediaViewerViewModel by viewModels {
+        albumId?.let {
+            MediaViewerViewModel.factory(lifecycleScope, it)
+        } ?: MediaViewerViewModel.factory(lifecycleScope)
+    }
 
     // Views
     private val adjustButton by getViewProperty<ImageButton>(R.id.adjustButton)
@@ -85,9 +89,8 @@ class MediaViewerFragment : Fragment(R.layout.fragment_media_viewer) {
 
                 initData(medias.toSet().sortedByDescending { it.dateAdded })
             } ?: albumId?.also {
-                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                    mediaViewModel.setBucketId(it)
-                    mediaViewModel.mediaForAlbum.collectLatest(::initData)
+                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    mediaViewModel.media.collectLatest(::initData)
                 }
             } ?: media?.also {
                 initData(listOf(it))

--- a/app/src/main/java/org/lineageos/glimpse/fragments/ReelsFragment.kt
+++ b/app/src/main/java/org/lineageos/glimpse/fragments/ReelsFragment.kt
@@ -40,7 +40,9 @@ import org.lineageos.glimpse.viewmodels.MediaViewModel
  */
 class ReelsFragment : Fragment(R.layout.fragment_reels) {
     // View models
-    private val mediaViewModel: MediaViewModel by viewModels { MediaViewModel.Factory }
+    private val mediaViewModel: MediaViewModel by viewModels {
+        MediaViewModel.factory(lifecycleScope)
+    }
 
     // Views
     private val appBarLayout by getViewProperty<AppBarLayout>(R.id.appBarLayout)
@@ -55,9 +57,9 @@ class ReelsFragment : Fragment(R.layout.fragment_reels) {
     private val permissionsUtils by lazy { PermissionsUtils(requireContext()) }
     private val permissionsGatedCallback = PermissionsGatedCallback(this) {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                mediaViewModel.media.collectLatest { data ->
-                    thumbnailAdapter.data = data.toTypedArray()
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                mediaViewModel.media.collectLatest {
+                    thumbnailAdapter.data = it.toTypedArray()
                 }
             }
         }

--- a/app/src/main/java/org/lineageos/glimpse/viewmodels/AlbumsViewModel.kt
+++ b/app/src/main/java/org/lineageos/glimpse/viewmodels/AlbumsViewModel.kt
@@ -10,30 +10,18 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flatMapLatest
 import org.lineageos.glimpse.GlimpseApplication
 import org.lineageos.glimpse.repository.MediaRepository
-import org.lineageos.glimpse.utils.MediaStoreBuckets
 
-open class MediaViewModel(
+open class AlbumsViewModel(
     private val mediaRepository: MediaRepository
 ) : ViewModel() {
-    val media = mediaRepository.media(MediaStoreBuckets.MEDIA_STORE_BUCKET_REELS.id)
-
-    private val bucketId = MutableStateFlow(MediaStoreBuckets.MEDIA_STORE_BUCKET_REELS.id)
-    fun setBucketId(bucketId: Int) {
-        this.bucketId.value = bucketId
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val mediaForAlbum = bucketId.flatMapLatest { mediaRepository.media(it) }
+    val albums = mediaRepository.albums()
 
     companion object {
         val Factory: ViewModelProvider.Factory = viewModelFactory {
             initializer {
-                MediaViewModel(
+                AlbumsViewModel(
                     mediaRepository = (this[APPLICATION_KEY] as GlimpseApplication).mediaRepository,
                 )
             }

--- a/app/src/main/java/org/lineageos/glimpse/viewmodels/AlbumsViewModel.kt
+++ b/app/src/main/java/org/lineageos/glimpse/viewmodels/AlbumsViewModel.kt
@@ -6,23 +6,31 @@
 package org.lineageos.glimpse.viewmodels
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
 import org.lineageos.glimpse.GlimpseApplication
 import org.lineageos.glimpse.repository.MediaRepository
 
 open class AlbumsViewModel(
-    private val mediaRepository: MediaRepository
+    private val mediaRepository: MediaRepository,
+    private val externalScope: CoroutineScope,
 ) : ViewModel() {
-    val albums = mediaRepository.albums()
+    val albums = mediaRepository.albums().shareIn(
+        externalScope,
+        replay = 1,
+        started = SharingStarted.WhileSubscribed()
+    )
 
     companion object {
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
+        fun factory(externalScope: CoroutineScope) = viewModelFactory {
             initializer {
                 AlbumsViewModel(
                     mediaRepository = (this[APPLICATION_KEY] as GlimpseApplication).mediaRepository,
+                    externalScope = externalScope,
                 )
             }
         }

--- a/app/src/main/java/org/lineageos/glimpse/viewmodels/MediaViewModel.kt
+++ b/app/src/main/java/org/lineageos/glimpse/viewmodels/MediaViewModel.kt
@@ -5,11 +5,9 @@
 
 package org.lineageos.glimpse.viewmodels
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
-import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,7 +18,7 @@ import org.lineageos.glimpse.repository.MediaRepository
 import org.lineageos.glimpse.utils.MediaStoreBuckets
 
 open class MediaViewModel(
-    private val savedStateHandle: SavedStateHandle, private val mediaRepository: MediaRepository
+    private val mediaRepository: MediaRepository
 ) : ViewModel() {
     val media = mediaRepository.media(MediaStoreBuckets.MEDIA_STORE_BUCKET_REELS.id)
     val albums = mediaRepository.albums()
@@ -37,7 +35,6 @@ open class MediaViewModel(
         val Factory: ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 MediaViewModel(
-                    savedStateHandle = createSavedStateHandle(),
                     mediaRepository = (this[APPLICATION_KEY] as GlimpseApplication).mediaRepository,
                 )
             }

--- a/app/src/main/java/org/lineageos/glimpse/viewmodels/MediaViewerViewModel.kt
+++ b/app/src/main/java/org/lineageos/glimpse/viewmodels/MediaViewerViewModel.kt
@@ -8,18 +8,21 @@ package org.lineageos.glimpse.viewmodels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.CoroutineScope
 import org.lineageos.glimpse.GlimpseApplication
 import org.lineageos.glimpse.repository.MediaRepository
+import org.lineageos.glimpse.utils.MediaStoreBuckets
 
 class MediaViewerViewModel(
     savedStateHandle: SavedStateHandle,
     mediaRepository: MediaRepository,
-) : MediaViewModel(mediaRepository) {
+    externalScope: CoroutineScope,
+    bucketId: Int,
+) : MediaViewModel(mediaRepository, externalScope, bucketId) {
     private val mediaPositionInternal = savedStateHandle.getLiveData<Int>(MEDIA_POSITION_KEY)
     val mediaPositionLiveData: LiveData<Int> = mediaPositionInternal
     var mediaPosition: Int
@@ -51,13 +54,19 @@ class MediaViewerViewModel(
     companion object {
         private const val MEDIA_POSITION_KEY = "position"
 
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                MediaViewerViewModel(
-                    savedStateHandle = createSavedStateHandle(),
-                    mediaRepository = (this[APPLICATION_KEY] as GlimpseApplication).mediaRepository,
-                )
+        fun factory(
+            externalScope: CoroutineScope,
+            bucketId: Int = MediaStoreBuckets.MEDIA_STORE_BUCKET_REELS.id
+        ) =
+            viewModelFactory {
+                initializer {
+                    MediaViewerViewModel(
+                        savedStateHandle = createSavedStateHandle(),
+                        mediaRepository = (this[APPLICATION_KEY] as GlimpseApplication).mediaRepository,
+                        externalScope = externalScope,
+                        bucketId = bucketId,
+                    )
+                }
             }
-        }
     }
 }

--- a/app/src/main/java/org/lineageos/glimpse/viewmodels/MediaViewerViewModel.kt
+++ b/app/src/main/java/org/lineageos/glimpse/viewmodels/MediaViewerViewModel.kt
@@ -19,7 +19,7 @@ import org.lineageos.glimpse.repository.MediaRepository
 class MediaViewerViewModel(
     savedStateHandle: SavedStateHandle,
     mediaRepository: MediaRepository,
-) : MediaViewModel(savedStateHandle, mediaRepository) {
+) : MediaViewModel(mediaRepository) {
     private val mediaPositionInternal = savedStateHandle.getLiveData<Int>(MEDIA_POSITION_KEY)
     val mediaPositionLiveData: LiveData<Int> = mediaPositionInternal
     var mediaPosition: Int


### PR DESCRIPTION
- Glimpse: Implement ACTION_REVIEW properly
- Glimpse: Don't use singleTop as launch mode
- Glimpse: Handle ACTION_REVIEW_SECURE
- Glimpse: Add support for read-only viewing
- Glimpse: Make bucket ID not null in flows
- Glimpse: Cleanup ViewModels parameters
- Glimpse: Move albums logic to AlbumsViewModel
- Glimpse: Use StateFlow in ViewModels
