### PR TITLE
Glimpse: Use BEHAVIOR_DEFAULT from non-compat class

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/ext/Window.kt
+++ b/app/src/main/java/org/lineageos/glimpse/ext/Window.kt
@@ -6,6 +6,7 @@
 package org.lineageos.glimpse.ext
 
 import android.view.Window
+import android.view.WindowInsetsController
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 
@@ -18,7 +19,8 @@ fun Window.setBarsVisibility(
     navigationBars: Boolean? = null,
 ) {
     // Configure the behavior of the hidden bars
-    windowInsetsController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+    // TODO: Use WindowInsetsControllerCompat.BEHAVIOR_DEFAULT when it becomes available in AOSP
+    windowInsetsController.systemBarsBehavior = WindowInsetsController.BEHAVIOR_DEFAULT
 
     val systemBarsType = WindowInsetsCompat.Type.systemBars()
     val statusBarsType = WindowInsetsCompat.Type.statusBars()


### PR DESCRIPTION
AOSP ships with androidx core-1.9.0-alpha03, which didn't have BEHAVIOR_DEFAULT defined yet.

Change-Id: I2e7e92c9e619f0761e8c43940a77ef91d82baa96