### PR TITLE
Glimpse: Generate the cursor indices

### DIFF
--- a/app/src/main/java/org/lineageos/glimpse/ext/Cursor.kt
+++ b/app/src/main/java/org/lineageos/glimpse/ext/Cursor.kt
@@ -9,7 +9,7 @@ import android.database.Cursor
 
 fun <T> Cursor?.mapEachRow(
     projection: Array<String>,
-    mapping: (Cursor, Array<Int>) -> T,
+    mapping: (Cursor, Array<Int>, Iterator<Int>) -> T,
 ) = this?.use {
     if (!moveToFirst()) {
         return@use emptyList<T>()
@@ -18,10 +18,16 @@ fun <T> Cursor?.mapEachRow(
     val indexCache = projection.map {
         getColumnIndexOrThrow(it)
     }.toTypedArray()
+    val indexGenerator = generateSequence(0) {
+        if (it >= indexCache.size - 1) null
+        else it + 1
+    }
 
     val data = mutableListOf<T>()
     do {
-        data.add(mapping(this, indexCache))
+        val iterator = indexGenerator.iterator()
+        data.add(mapping(this, indexCache, iterator))
+        if (iterator.hasNext()) throw IllegalStateException("Iterator should be empty")
     } while (moveToNext())
 
     data.toList()

--- a/app/src/main/java/org/lineageos/glimpse/ext/Flow.kt
+++ b/app/src/main/java/org/lineageos/glimpse/ext/Flow.kt
@@ -11,5 +11,5 @@ import kotlinx.coroutines.flow.map
 
 fun <T> Flow<Cursor?>.mapEachRow(
     projection: Array<String>,
-    mapping: (Cursor, Array<Int>) -> T,
+    mapping: (Cursor, Array<Int>, Iterator<Int>) -> T,
 ) = map { it.mapEachRow(projection, mapping) }

--- a/app/src/main/java/org/lineageos/glimpse/flow/MediaFlow.kt
+++ b/app/src/main/java/org/lineageos/glimpse/flow/MediaFlow.kt
@@ -91,21 +91,19 @@ class MediaFlow(private val context: Context, private val bucketId: Int) : Query
             MediaStore.Files.FileColumns.HEIGHT,
             MediaStore.Files.FileColumns.ORIENTATION,
         )
-    ) { it, indexCache ->
-        var i = 0
-
-        val id = it.getLong(indexCache[i++])
-        val bucketId = it.getInt(indexCache[i++])
-        val displayName = it.getString(indexCache[i++])
-        val isFavorite = it.getInt(indexCache[i++])
-        val isTrashed = it.getInt(indexCache[i++])
-        val mediaType = it.getInt(indexCache[i++])
-        val mimeType = it.getString(indexCache[i++])
-        val dateAdded = it.getLong(indexCache[i++])
-        val dateModified = it.getLong(indexCache[i++])
-        val width = it.getInt(indexCache[i++])
-        val height = it.getInt(indexCache[i++])
-        val orientation = it.getInt(indexCache[i++])
+    ) { it, indexCache, indexGenerator ->
+        val id = it.getLong(indexCache[indexGenerator.next()])
+        val bucketId = it.getInt(indexCache[indexGenerator.next()])
+        val displayName = it.getString(indexCache[indexGenerator.next()])
+        val isFavorite = it.getInt(indexCache[indexGenerator.next()])
+        val isTrashed = it.getInt(indexCache[indexGenerator.next()])
+        val mediaType = it.getInt(indexCache[indexGenerator.next()])
+        val mimeType = it.getString(indexCache[indexGenerator.next()])
+        val dateAdded = it.getLong(indexCache[indexGenerator.next()])
+        val dateModified = it.getLong(indexCache[indexGenerator.next()])
+        val width = it.getInt(indexCache[indexGenerator.next()])
+        val height = it.getInt(indexCache[indexGenerator.next()])
+        val orientation = it.getInt(indexCache[indexGenerator.next()])
 
         Media.fromMediaStore(
             id,


### PR DESCRIPTION
It's not as good looking, or as performant
but it ensures we're never trying to read more
rows than requested and we're reading all the requested
rows.

Change-Id: Iaee385ec036e09241f1ca694984b0079feee42e7
Signed-off-by: Luca Stefani <luca.stefani.ge1@gmail.com>
